### PR TITLE
add bs-toast component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-components",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Bootstrap Stenciljs Components",
   "author": "Jason Cubic",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ See [documentation](https://bs-components.github.io/) for installation and getti
 
 Built Using:
 
-- [bootstrap css from v4.1.3](https://github.com/twbs/bootstrap/releases/tag/v4.1.3)
+- [bootstrap css from v4.4.1](https://github.com/twbs/bootstrap/releases/tag/v4.4.1)
 - [stencil](https://stenciljs.com/)
 
 Tests Using:
@@ -38,6 +38,7 @@ Status:
 - [x] alert - run tests using: `yarn test-bs-alert`
 - [x] tab - run tests using: `yarn test-bs-tab`
 - [x] scrollspy - run tests using: `yarn test-bs-scrollspy`
+- [ ] toast - run tests using: `yarn test-bs-toast`
 - [ ] carousel not planned currently but maybe later
 
 For all of the other bootstrap components a web component solution is not needed because they can be done with normal html and css. Use the bootstrap webpage component documents.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -78,6 +78,18 @@ export namespace Components {
     'shownEventName': string;
     'tab': (tabOptions?: {}, triggeringButton?: any) => Promise<boolean | HTMLElement>;
   }
+  interface BsToast {
+    'autohide': boolean;
+    'delay': number;
+    'hiddenEventName': string;
+    'hide': () => Promise<void>;
+    'hideEventName': string;
+    'noSelfRemoveFromDom': boolean;
+    'show': () => Promise<void>;
+    'showEventName': string;
+    'shownEventName': string;
+    'toast': (toastOptions: any) => Promise<any>;
+  }
   interface BsTooltip {
     'bsContent': string;
     'bsTitle': string;
@@ -146,6 +158,12 @@ declare global {
     new (): HTMLBsTabElement;
   };
 
+  interface HTMLBsToastElement extends Components.BsToast, HTMLStencilElement {}
+  var HTMLBsToastElement: {
+    prototype: HTMLBsToastElement;
+    new (): HTMLBsToastElement;
+  };
+
   interface HTMLBsTooltipElement extends Components.BsTooltip, HTMLStencilElement {}
   var HTMLBsTooltipElement: {
     prototype: HTMLBsTooltipElement;
@@ -159,6 +177,7 @@ declare global {
     'bs-modal': HTMLBsModalElement;
     'bs-scrollspy': HTMLBsScrollspyElement;
     'bs-tab': HTMLBsTabElement;
+    'bs-toast': HTMLBsToastElement;
     'bs-tooltip': HTMLBsTooltipElement;
   }
 }
@@ -220,6 +239,15 @@ declare namespace LocalJSX {
     'showTab'?: boolean;
     'shownEventName'?: string;
   }
+  interface BsToast {
+    'autohide'?: boolean;
+    'delay'?: number;
+    'hiddenEventName'?: string;
+    'hideEventName'?: string;
+    'noSelfRemoveFromDom'?: boolean;
+    'showEventName'?: string;
+    'shownEventName'?: string;
+  }
   interface BsTooltip {
     'bsContent'?: string;
     'bsTitle'?: string;
@@ -248,6 +276,7 @@ declare namespace LocalJSX {
     'bs-modal': BsModal;
     'bs-scrollspy': BsScrollspy;
     'bs-tab': BsTab;
+    'bs-toast': BsToast;
     'bs-tooltip': BsTooltip;
   }
 }
@@ -265,6 +294,7 @@ declare module "@stencil/core" {
       'bs-modal': LocalJSX.BsModal & JSXBase.HTMLAttributes<HTMLBsModalElement>;
       'bs-scrollspy': LocalJSX.BsScrollspy & JSXBase.HTMLAttributes<HTMLBsScrollspyElement>;
       'bs-tab': LocalJSX.BsTab & JSXBase.HTMLAttributes<HTMLBsTabElement>;
+      'bs-toast': LocalJSX.BsToast & JSXBase.HTMLAttributes<HTMLBsToastElement>;
       'bs-tooltip': LocalJSX.BsTooltip & JSXBase.HTMLAttributes<HTMLBsTooltipElement>;
     }
   }

--- a/src/components/bs-toast/bs-toast.css
+++ b/src/components/bs-toast/bs-toast.css
@@ -1,0 +1,3 @@
+bs-toast {
+  display: block;
+}

--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -64,17 +64,6 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
     });
   }
 
-  @Watch('dismiss')
-  handleActiveWatch(newValue /* , oldValue */) {
-    // console.log('newValue: ', newValue);
-    if (newValue === true) {
-      this.hide();
-      return;
-    }
-    this.show();
-  }
-
-
   @Method()
   async hide() {
     if (!hasClass(this.toastEl, 'show')) {

--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -1,0 +1,153 @@
+import {
+  Component, // eslint-disable-line no-unused-vars
+  Prop,
+  Listen, // eslint-disable-line no-unused-vars
+  Element,
+  Method, // eslint-disable-line no-unused-vars
+  Watch, h, // eslint-disable-line no-unused-vars
+} from '@stencil/core';
+
+import _ from 'lodash';
+import closest from '../../utilities/closest';
+import customEvent from '../../utilities/custom-event';
+import removeClass from '../../utilities/remove-class';
+import addClass from '../../utilities/add-class';
+import hasClass from '../../utilities/has-class';
+import getTransitionDurationFromElement from '../../utilities/get-transition-duration-from-element';
+
+@Component({tag: 'bs-toast', styleUrl: 'bs-toast.css', shadow: false})
+export class BsToast { // eslint-disable-line import/prefer-default-export
+  @Element() toastEl: HTMLElement;
+
+  @Prop() showEventName: string = 'show.bs.toast';
+  @Prop() shownEventName: string = 'shown.bs.toast';
+  @Prop() hideEventName: string = 'hide.bs.toast';
+  @Prop() hiddenEventName: string = 'hidden.bs.toast';
+
+  @Prop() noSelfRemoveFromDom: boolean = true;
+  @Prop({mutable: true}) autohide: boolean = true;
+  @Prop({mutable: true}) delay: number = 500;
+
+  componentWillLoad() {
+  }
+
+  @Listen('click')
+  handleFocusOut(event) {
+    const closestDismissEl = closest(event.target, '[data-dismiss="toast"]');
+    if (closestDismissEl && this.toastEl.contains(closestDismissEl)) {
+      if (event.stopPropagation) {
+        event.stopPropagation();
+        event.preventDefault();
+      }
+      this.hide();
+    }
+  }
+
+  @Listen('shown.bs.toast')
+  handleShown() {
+    if(!this.autohide)
+      return;
+
+    setTimeout(() => this.hide(), this.delay);
+  }
+
+  destroyToast() {
+    if (!this.noSelfRemoveFromDom) {
+      this.toastEl.parentNode.removeChild(this.toastEl);
+    }
+    window.requestAnimationFrame(() => { // trick to ensure all page updates are completed before running code
+      window.requestAnimationFrame(() => { // discussed here:  https://www.youtube.com/watch?v=aCMbSyngXB4&t=11m
+        setTimeout(() => {
+          customEvent(this.toastEl, this.hiddenEventName);
+        }, 0);
+      });
+    });
+  }
+
+  @Watch('dismiss')
+  handleActiveWatch(newValue /* , oldValue */) {
+    // console.log('newValue: ', newValue);
+    if (newValue === true) {
+      this.hide();
+      return;
+    }
+    this.show();
+  }
+
+
+  @Method()
+  async hide() {
+    if (!hasClass(this.toastEl, 'show')) {
+      return;
+    }
+
+    const closeEvent = customEvent(this.toastEl, this.hideEventName);
+    if (closeEvent.defaultPrevented) {
+      return;
+    }
+
+    removeClass(this.toastEl, 'show');
+
+    if (!hasClass(this.toastEl, 'fade')) {
+      this.destroyToast();
+      return;
+    }
+    const transitionDuration = getTransitionDurationFromElement(this.toastEl);
+    setTimeout(() => {
+      this.destroyToast();
+    }, transitionDuration);
+  }
+
+  @Method()
+  async show() {
+    if (hasClass(this.toastEl, 'show')) {
+      return;
+    }
+
+    const openEvent = customEvent(this.toastEl, this.showEventName);
+
+    if (openEvent.defaultPrevented) {
+      return;
+    }
+
+    removeClass(this.toastEl, 'hide');
+    addClass(this.toastEl, 'show');
+    const transitionDuration = getTransitionDurationFromElement(this.toastEl);
+    setTimeout(() => {
+      window.requestAnimationFrame(() => { // trick to ensure all page updates are completed before running code
+        window.requestAnimationFrame(() => { // discussed here:  https://www.youtube.com/watch?v=aCMbSyngXB4&t=11m
+          setTimeout(() => {
+            customEvent(this.toastEl, this.shownEventName);
+          }, 0);
+        });
+      });
+    }, transitionDuration);
+  }
+
+  @Method()
+  async toast(toastOptions): Promise<any> {
+    if (_.size(toastOptions) === 0) {
+      return this.toastEl;
+    }
+    if (toastOptions === 'hide') {
+      await this.hide();
+      return true;
+    }
+    if (toastOptions === 'show') {
+      await this.show();
+      return true;
+    }
+    if (toastOptions === 'dispose') {
+      await this.hide();
+      return true;
+    }
+    if (typeof toastOptions === 'string') {
+      throw new Error(`No method named "${toastOptions}"`);
+    }
+    return null;
+  }
+
+  render() {
+    return (<slot/>);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <title>bs-components</title>
 
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
   <!-- https://bootswatch.com/api/4.json -->
   <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0/cyborg/bootstrap.min.css"> -->
@@ -450,6 +450,35 @@
     <bs-tooltip class="d-inline-block" tabindex="0" data-toggle="tooltip" title="Disabled tooltip">
       <button class="btn btn-primary" style="pointer-events: none;" type="button" disabled>Disabled button</button>
     </bs-tooltip>
+
+    <hr>
+
+    <h2>Toasts</h2>
+
+    <bs-toast id="toast1" class="toast fade" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast-header">
+        <svg class="bd-placeholder-img rounded mr-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#007aff"></rect></svg>
+        <strong class="mr-auto">Bootstrap</strong>
+        <small>11 mins ago</small>
+        <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="toast-body">
+        Hello, world! This is a toast message.
+      </div>
+    </bs-toast>
+
+    <button id="showToast1Button" class="btn btn-primary">Show Toast</button>
+
+    <script type="application/javascript">
+
+      const onShowToast1ButtonClick = e => {
+        document.getElementById('toast1').show();
+      };
+
+      document.getElementById('showToast1Button').addEventListener('click', onShowToast1ButtonClick);
+    </script>
 
     <hr>
     <p>&nbsp;</p>


### PR DESCRIPTION
This PR adds a new component with tag `bs-toast`, representing Bootstrap 4.4's [Toast](https://getbootstrap.com/docs/4.4/components/toasts) component.

![toast-1](https://user-images.githubusercontent.com/938393/74162408-02a1a080-4c21-11ea-8733-022dd885b66a.gif)

I attempted to write tests, but failed at getting TestCafe to even display help. Any help in this area would be much appreciated.

Fixes #3 