### PR TITLE
Update bs-toast.tsx to use same default as other components

### DIFF
--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -24,7 +24,7 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
   @Prop() hideEventName: string = 'hide.bs.toast';
   @Prop() hiddenEventName: string = 'hidden.bs.toast';
 
-  @Prop() noSelfRemoveFromDom: boolean = true;
+  @Prop() noSelfRemoveFromDom: boolean = false;
   @Prop({mutable: true}) autohide: boolean = true;
   @Prop({mutable: true}) delay: number = 500;
 

--- a/src/index.html
+++ b/src/index.html
@@ -455,7 +455,7 @@
 
     <h2>Toasts</h2>
 
-    <bs-toast id="toast1" class="toast fade" role="alert" aria-live="assertive" aria-atomic="true">
+    <bs-toast id="toast1" class="toast fade" role="alert" aria-live="assertive" aria-atomic="true" no-self-remove-from-dom="true">
       <div class="toast-header">
         <svg class="bd-placeholder-img rounded mr-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#007aff"></rect></svg>
         <strong class="mr-auto">Bootstrap</strong>


### PR DESCRIPTION
This PR changes the default value of the `noSelfRemoveFromDom` property to `false`. The value of `true` makes sense for the demo page, where it would be inconvenient for the DOM element to be destroyed, but in real-world scenarios, it's probably more convenient if the toast message self-destructs automatically upon hide.