### PR TITLE
Auto hide toast on load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ www/
 log.txt
 *.sublime-project
 *.sublime-workspace
+*.orig
 
 .stencil/
 .idea/

--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -29,6 +29,7 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
   @Prop({mutable: true}) delay: number = 500;
 
   componentWillLoad() {
+    this.autoHideToast();
   }
 
   @Listen('click')
@@ -45,10 +46,7 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
 
   @Listen('shown.bs.toast')
   handleShown() {
-    if(!this.autohide)
-      return;
-
-    setTimeout(() => this.hide(), this.delay);
+    this.autoHideToast();
   }
 
   destroyToast() {
@@ -64,11 +62,19 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
     });
   }
 
+  autoHideToast() {
+    if (!this.autohide || !this.isShown())
+      return;
+
+    setTimeout(() => this.hide(), this.delay);
+  }
+
+  private isShown = () => hasClass(this.toastEl, 'show');
+
   @Method()
   async hide() {
-    if (!hasClass(this.toastEl, 'show')) {
+    if (!this.isShown())
       return;
-    }
 
     const closeEvent = customEvent(this.toastEl, this.hideEventName);
     if (closeEvent.defaultPrevented) {
@@ -89,7 +95,7 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
 
   @Method()
   async show() {
-    if (hasClass(this.toastEl, 'show')) {
+    if (this.isShown()) {
       return;
     }
 

--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -44,11 +44,6 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
     }
   }
 
-  @Listen('shown.bs.toast')
-  handleShown() {
-    this.autoHideToast();
-  }
-
   destroyToast() {
     if (!this.noSelfRemoveFromDom) {
       this.toastEl.parentNode.removeChild(this.toastEl);
@@ -113,6 +108,7 @@ export class BsToast { // eslint-disable-line import/prefer-default-export
         window.requestAnimationFrame(() => { // discussed here:  https://www.youtube.com/watch?v=aCMbSyngXB4&t=11m
           setTimeout(() => {
             customEvent(this.toastEl, this.shownEventName);
+            this.autoHideToast();
           }, 0);
         });
       });

--- a/src/components/bs-toast/bs-toast.tsx
+++ b/src/components/bs-toast/bs-toast.tsx
@@ -4,7 +4,7 @@ import {
   Listen, // eslint-disable-line no-unused-vars
   Element,
   Method, // eslint-disable-line no-unused-vars
-  Watch, h, // eslint-disable-line no-unused-vars
+  h, // eslint-disable-line no-unused-vars
 } from '@stencil/core';
 
 import _ from 'lodash';

--- a/src/index.html
+++ b/src/index.html
@@ -455,7 +455,7 @@
 
     <h2>Toasts</h2>
 
-    <bs-toast id="toast1" class="toast fade" role="alert" aria-live="assertive" aria-atomic="true">
+    <bs-toast id="toast1" class="toast fade" role="alert" aria-live="assertive" aria-atomic="true" no-self-remove-from-dom="true">
       <div class="toast-header">
         <svg class="bd-placeholder-img rounded mr-2" width="20" height="20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#007aff"></rect></svg>
         <strong class="mr-auto">Bootstrap</strong>


### PR DESCRIPTION
As I'm applying the Toast component, I'm running into small issues here and there. This PR fixes an issue where the toast component does not automatically hide when it's initially shown. The expected behavior is that the component should automatically hide if `autohide` is `true`, both when the component transitions from hidden => shown, and when the component is initialized in the "shown" state.